### PR TITLE
Fix: EmailNotificationMessage 기본 생성자 누락

### DIFF
--- a/src/main/java/com/ganzi/notifier/infra/messaging/EmailNotificationMessage.java
+++ b/src/main/java/com/ganzi/notifier/infra/messaging/EmailNotificationMessage.java
@@ -2,11 +2,13 @@ package com.ganzi.notifier.infra.messaging;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import java.util.UUID;
 
 @Getter
 @AllArgsConstructor
+@NoArgsConstructor
 public class EmailNotificationMessage implements NotificationMessage {
     private UUID id;
     private EmailTargetMessage target;


### PR DESCRIPTION
## 🧾 개요
EmailNotificationMessage 기본 생성자 누락

---

## ✅ 작업 내용
- [ ] EmailNotificationMessage 기본 생성자 Lombok 적용

---

## 🏷️ 관련 태그 (선택)
`핫픽스`
